### PR TITLE
Fix bug per rimozione intestazione

### DIFF
--- a/src/PhpPec/Parser/PostacertParser.php
+++ b/src/PhpPec/Parser/PostacertParser.php
@@ -150,7 +150,7 @@ class PostacertParser
                 preg_match('/Content-Transfer-Encoding: (\w+)/', $parteMessaggio, $encoding);
                 if(count($encoding) > 0) {
                     // Elimino l'intestazione della parte del messaggio
-                    $parteMessaggio = trim(preg_replace('/^Content[\w-\s:\/;=]+\n\n/', '', $parteMessaggio));
+                    $parteMessaggio = trim(preg_replace('/Content[^\n]*/', '', $parteMessaggio));
                     switch (strtolower($encoding[1])) {
                         case 'base64':
                             $parteMessaggio = base64_decode($parteMessaggio);


### PR DESCRIPTION
La funzione pre_match  presente il testo del messaggo contenente dei fine riga vengono inglobati nel match della regex e cancellati insieme ai "Content-*". Il risultato del pre_match era in alcuni casi quindi una stringa vuota, come se il messaggio non contenesse nessun testo. 
La modifica proposta elimina solo le righe contenenti "Content-*" e lascia intatto il resto del messaggio.