### PR TITLE
Update PecMessage.php

### DIFF
--- a/src/PhpPec/PecMessage.php
+++ b/src/PhpPec/PecMessage.php
@@ -123,7 +123,7 @@ class PecMessage extends Message implements PecMessageInterface
          */
         if($this->getTrasporto()) {
             if(is_array($mittente) && count($mittente) > 0) {
-                preg_match('/Per conto di: ([\w-.]+@[\w.-]+)/', $mittente['name'], $match);
+                preg_match('/Per conto di: ([\w\-.]+@[\w.\-]+)/', $mittente['name'], $match);
                 if(count($match) == 2) {
                     return $match[1];
                 }


### PR DESCRIPTION
PCRE2 (php >=7.3) is more strict in the pattern validations, so hyphen need to be escape in the expression to avoid "preg_match(): Compilation failed: invalid range in character class at offset"